### PR TITLE
fixed #37: adjust default page for player page

### DIFF
--- a/app/app/scripts/entry.js
+++ b/app/app/scripts/entry.js
@@ -30,6 +30,6 @@ app.config([ '$routeProvider', '$locationProvider', function($routeProvider, $lo
         meta : 'twitter',
         templateUrl : '/partials/twitter.html',
     }).otherwise({
-        redirectTo : '/atbats'
+        redirectTo : document.body.getAttribute("data-default-route")
     });
 } ]);

--- a/app/app/views/player.html
+++ b/app/app/views/player.html
@@ -10,7 +10,7 @@
     
     <% include templates/css.html %>
 </head>
-<body ng-app="pitchfx">
+<body ng-app="pitchfx" data-default-route="<%if (playerInfo.primary_position==1) { %>/pitches<%} else {%>/atbats<%}%>">
 	<header class="navbar navbar-default navbar-fixed-top">
 		<div class="container">
 			<div class="navbar-header">


### PR DESCRIPTION
add data-default-route attribute to body of player.html EJS. data-default-route is read by entry.js into redirectTo (document.body.getAttribute) so pitchers route to /pitches and batters route to /atbats. if pull request is accepted, feel free to close issue #37.
