### PR TITLE
fixed #32: calc wOBA with season coefficients

### DIFF
--- a/app/lib/controllers/apis/stats.js
+++ b/app/lib/controllers/apis/stats.js
@@ -104,6 +104,7 @@ function calculateResults(docs, statsYear) {
 function completeStats(results) {
     calcBattingAverage(results);
     calcWOBA(results);
+    calcWRAA(results);
     calcSLG(results);
     calcOBP(results);
     calcBABIP(results);
@@ -111,7 +112,7 @@ function completeStats(results) {
 }
 
 /**
- * Calculates Runners Moved Indicator
+ * Calculate Runners Moved Indicator
  * 
  * @param results
  */
@@ -155,7 +156,7 @@ function calcSLG(results) {
 }
 
 /**
- * Weighted On Base Average calculation
+ * Calculate Weighted On Base Average
  * 
  * @param results
  */
@@ -173,7 +174,19 @@ function calcWOBA(results) {
 }
 
 /**
- * Batting average calculation
+ * Calculate Weighted Runs Above Average
+ * 
+ * @param results
+ */
+function calcWRAA(results) {
+    var coefficients = statsConstantsService.getCoefficients(results.year);
+    if (results.plateAppearances) {
+        results.wRAA = ((results.wOBA - coefficients.wOBA) / coefficients.wOBAScale) * results.plateAppearances;
+    }
+}
+
+/**
+ * Calculate Batting Average
  * 
  * @param results
  */

--- a/app/lib/services/statsConstantsService.js
+++ b/app/lib/services/statsConstantsService.js
@@ -1,0 +1,131 @@
+/**
+ * @param {Moment} start - starting date
+ * @param {Moment} end - ending date
+ * @returns {Array} coefficients
+ * Source: http://www.fangraphs.com/guts.aspx
+ */
+exports.getCoefficients = function(statsYear) {
+    var yearlyCoefficients = {
+        '2014' : {
+            'wOBA':.314,
+            'wOBAScale':1.277,
+            'wBB':.690,
+            'wHBP':.722,
+            'w1B':.888,
+            'w2B':1.271,
+            'w3B':1.616,
+            'wHR':2.101,
+            'runSB':.200,
+            'runCS':-.384,
+            'RperPA':.110,
+            'RperW':9.264,
+            'cFIP':3.048
+        },
+        '2013' : {
+            'wOBA' : .314,
+            'wOBAScale' : 1.277,
+            'wBB' : .690,
+            'wHBP' : .722,
+            'w1B' : .888,
+            'w2B' : 1.271,
+            'w3B' : 1.616,
+            'wHR' : 2.101,
+            'runSB' : .200,
+            'runCS' : -.384,
+            'RperPA' : .110,
+            'RperW' : 9.264,
+            'cFIP' : 3.048
+        },
+        '2012' : {
+            'wOBA' : .315,
+            'wOBAScale' : 1.245,
+            'wBB' : .691,
+            'wHBP' : .722,
+            'w1B' : .884,
+            'w2B' : 1.257,
+            'w3B' : 1.593,
+            'wHR' : 2.058,
+            'runSB' : .200,
+            'runCS' : -.398,
+            'RperPA' : .114,
+            'RperW' : 9.544,
+            'cFIP' : 3.095
+        },
+        '2011' : {
+            'wOBA' : .316,
+            'wOBAScale' : 1.264,
+            'wBB' : .694,
+            'wHBP' : .726,
+            'w1B' : .890,
+            'w2B' : 1.270,
+            'w3B' : 1.611,
+            'wHR' : 2.086,
+            'runSB' : .200,
+            'runCS' : -.394,
+            'RperPA' : .112,
+            'RperW' : 9.454,
+            'cFIP' : 3.025
+        },
+        '2010' : {
+            'wOBA' : .321,
+            'wOBAScale' : 1.251,
+            'wBB' : .701,
+            'wHBP' : .732,
+            'w1B' : .895,
+            'w2B' : 1.270,
+            'w3B' : 1.608,
+            'wHR' : 2.072,
+            'runSB' : .200,
+            'runCS' : -.403,
+            'RperPA' : .115,
+            'RperW' : 9.643,
+            'cFIP' : 3.079
+        },
+        '2009' : {
+            'wOBA' : .329,
+            'wOBAScale' : 1.210,
+            'wBB' : .707,
+            'wHBP' : .737,
+            'w1B' : .895,
+            'w2B' : 1.258,
+            'w3B' : 1.585,
+            'wHR' : 2.023,
+            'runSB' : .200,
+            'runCS' : -.420,
+            'RperPA' : .120,
+            'RperW' : 9.994,
+            'cFIP' : 3.097
+        },
+        '2008' : {
+            'wOBA' : .328,
+            'wOBAScale' : 1.211,
+            'wBB' : .708,
+            'wHBP' : .739,
+            'w1B' : .896,
+            'w2B' : 1.259,
+            'w3B' : 1.587,
+            'wHR' : 2.024,
+            'runSB' : .200,
+            'runCS' : -.422,
+            'RperPA' : .120,
+            'RperW' : 10.032,
+            'cFIP' : 3.132
+        },
+        '2007' : {
+            'wOBA' : .331,
+            'wOBAScale' : 1.192,
+            'wBB' : .711,
+            'wHBP' : .741,
+            'w1B' : .896,
+            'w2B' : 1.253,
+            'w3B' : 1.575,
+            'wHR' : 1.999,
+            'runSB' : .200,
+            'runCS' : -.433,
+            'RperPA' : .124,
+            'RperW' : 10.250,
+            'cFIP' : 3.240
+        }
+    }
+    return yearlyCoefficients[statsYear];
+};


### PR DESCRIPTION
Added statsConstantsService to store yearly coefficients for wOBA and
FIP. We can store other historical seasonal coefficients here as well.
The last statsYear of the filter is passed to calculateResults and
stored in results. Then getCoefficients(results.year) fetches the
coefficients.
