### PR TITLE
adding contact and per swing heatmaps, functions, and karma tests

### DIFF
--- a/app/app/scripts/controllers/pitchStats.js
+++ b/app/app/scripts/controllers/pitchStats.js
@@ -19,38 +19,8 @@ angular.module('pitchfxApp').controller('PitchstatsCtrl', ['$rootScope', '$scope
         $scope.model = {
             zoneCharts: [
             {
-                title: 'wOBA/BIP',
-                group: 'Sabermetric Outcomes',
-                id: 'woba',
-                max: 0.500,
-                generator: function()
-                {
-                    $scope.model.zonePoints = zones.getWOBARates();
-                }
-            },
-            {
-                title: 'BABIP',
-                group: 'Sabermetric Outcomes',
-                id: 'babip',
-                max: 0.400,
-                generator: function()
-                {
-                    $scope.model.zonePoints = zones.getBABIPRates();
-                }
-            },
-            {
-                title: 'BIP Rate',
-                group: 'Sabermetric Outcomes',
-                id: 'bipRate',
-                max: 0.400,
-                generator: function()
-                {
-                    $scope.model.zonePoints = zones.getBIPRates();
-                }
-            },
-            {
                 title: 'Swing Rate',
-                group: 'Plate Discipline',
+                group: 'Pitch Results',
                 id: 'swingRate',
                 max: 0.800,
                 generator: function()
@@ -59,33 +29,83 @@ angular.module('pitchfxApp').controller('PitchstatsCtrl', ['$rootScope', '$scope
                 }
             },
             {
+                title: 'Contact Rate',
+                group: 'Pitch Results',
+                id: 'contactRate',
+                max: 0.600,
+                generator: function()
+                {
+                    $scope.model.zonePoints = zones.getContactRates();
+                }
+            },
+            {
                 title: 'Whiff Rate',
-                group: 'Plate Discipline',
+                group: 'Pitch Results',
                 id: 'whiffRate',
-                max: 0.200,
+                max: 0.400,
                 generator: function()
                 {
                     $scope.model.zonePoints = zones.getWhiffRates();
                 }
             },
             {
+                title: 'Called Strike Rate',
+                group: 'Pitch Results',
+                id: 'calledStrikeRate',
+                max: 0.500,
+                generator: function()
+                {
+                    $scope.model.zonePoints = zones.getCalledStrikeRates();
+                }
+            },
+            {
+                title: 'Ball In Play Rate',
+                group: 'Pitch Results',
+                id: 'bipRate',
+                max: 0.400,
+                generator: function()
+                {
+                    $scope.model.zonePoints = zones.getBIPRates();
+                }
+            },
+            {
+                title: 'Contact/Swing',
+                group: 'Swing Results',
+                id: 'contactPerSwing',
+                max: 0.800,
+                generator: function()
+                {
+                    $scope.model.zonePoints = zones.getContactPerSwingRates();
+                }
+            },
+            {
                 title: 'Whiffs/Swing',
-                group: 'Plate Discipline',
+                group: 'Swing Results',
                 id: 'whiffsPerSwing',
-                max: 0.600,
+                max: 0.400,
                 generator: function()
                 {
                     $scope.model.zonePoints = zones.getWhiffsPerSwingRates();
                 }
             },
             {
-                title: 'Called Strike Rate',
-                group: 'Plate Discipline',
-                id: 'calledStrikeRate',
+                title: 'Fouls/Swing',
+                group: 'Swing Results',
+                id: 'foulsPerSwing',
                 max: 0.500,
                 generator: function()
                 {
-                    $scope.model.zonePoints = zones.getCalledStrikeRates();
+                    $scope.model.zonePoints = zones.getFoulsPerSwingRates();
+                }
+            },
+            {
+                title: 'BIP/Swing',
+                group: 'Swing Results',
+                id: 'bipPerSwing',
+                max: 0.500,
+                generator: function()
+                {
+                    $scope.model.zonePoints = zones.getBIPPerSwingRates();
                 }
             },
             {
@@ -126,6 +146,26 @@ angular.module('pitchfxApp').controller('PitchstatsCtrl', ['$rootScope', '$scope
                 generator: function()
                 {
                     $scope.model.zonePoints = zones.getPopupRates();
+                }
+            },
+            {
+                title: 'wOBA/BIP',
+                group: 'Sabermetric Results',
+                id: 'woba',
+                max: 0.500,
+                generator: function()
+                {
+                    $scope.model.zonePoints = zones.getWOBARates();
+                }
+            },
+            {
+                title: 'BABIP',
+                group: 'Sabermetric Results',
+                id: 'babip',
+                max: 0.400,
+                generator: function()
+                {
+                    $scope.model.zonePoints = zones.getBABIPRates();
                 }
             }, ],
         };

--- a/app/app/scripts/pojos/Zone.js
+++ b/app/app/scripts/pojos/Zone.js
@@ -113,7 +113,121 @@ pitchfx.Zone.prototype.getBIPRate = function()
 };
 
 /**
- * Get the whiff rate across all pitches in this zone
+ * Get the balls in play rate across all swings in this zone
+ *
+ * @returns {Number}
+ */
+pitchfx.Zone.prototype.getBIPPerSwingRate = function()
+{
+    var bip = 0,
+        swings = 0,
+        val = 0;
+
+    angular.forEach(this.pitches, function(pitch)
+    {
+        if (pitch.isSwing())
+        {
+            swings++;
+        }
+        if (pitch.isBallInPlay())
+        {
+            bip++;
+        }
+    });
+    if (swings === 0)
+    {
+        return new pitchfx.ZoneStat(0, '0% (0/0)');
+    }
+    val = bip / swings;
+    return new pitchfx.ZoneStat(val, (val * 100).toFixed(0) + '% (' + bip + '/' + swings + ')');
+};
+
+/**
+ * Get the foul rate across all pitches in this zone
+ *
+ * @returns {Number}
+ */
+pitchfx.Zone.prototype.getFoulRate = function()
+{
+    var pitches = this.pitches.length,
+        fouls = 0,
+        val = 0;
+
+    angular.forEach(this.pitches, function(pitch)
+    {
+        if (pitch.isFoul())
+        {
+            fouls++;
+        }
+    });
+    if (pitches === 0)
+    {
+        return new pitchfx.ZoneStat(0, '0% (0/0)');
+    }
+
+    val = fouls / pitches;
+    return new pitchfx.ZoneStat(val, (val * 100).toFixed(0) + '% (' + fouls + '/' + pitches + ')');
+};
+
+/**
+ * Get the foul rate across all swings in this zone
+ *
+ * @returns {Number}
+ */
+pitchfx.Zone.prototype.getFoulsPerSwingRate = function()
+{
+    var fouls = 0,
+        swings = 0,
+        val = 0;
+
+    angular.forEach(this.pitches, function(pitch)
+    {
+        if (pitch.isSwing())
+        {
+            swings++;
+        }
+        if (pitch.isFoul())
+        {
+            fouls++;
+        }
+    });
+    if (swings === 0)
+    {
+        return new pitchfx.ZoneStat(0, '0% (0/0)');
+    }
+    val = fouls / swings;
+    return new pitchfx.ZoneStat(val, (val * 100).toFixed(0) + '% (' + fouls + '/' + swings + ')');
+};
+
+/**
+ * Get the whiff rate for this zone
+ *
+ * @returns {pitchfx.ZoneStat}
+ */
+pitchfx.Zone.prototype.getWhiffRate = function()
+{
+    var pitches = this.pitches.length,
+        whiffs = 0,
+        val = 0;
+    if (pitches === 0)
+    {
+        return new pitchfx.ZoneStat(0, '0% (0/0)');
+    }
+
+    angular.forEach(this.pitches, function(pitch)
+    {
+        if (pitch.isWhiff())
+        {
+            whiffs++;
+        }
+    });
+
+    val = whiffs / pitches;
+    return new pitchfx.ZoneStat(val, (val * 100).toFixed(0) + '% (' + whiffs + '/' + pitches + ')');
+};
+
+/**
+ * Get the whiff rate across all swings in this zone
  *
  * @returns {Number}
  */
@@ -143,14 +257,14 @@ pitchfx.Zone.prototype.getWhiffsPerSwingRate = function()
 };
 
 /**
- * Get the whiff rate for this zone
+ * Get the contact rate for this zone
  *
  * @returns {pitchfx.ZoneStat}
  */
-pitchfx.Zone.prototype.getWhiffRate = function()
+pitchfx.Zone.prototype.getContactRate = function()
 {
     var pitches = this.pitches.length,
-        whiffs = 0,
+        contact = 0,
         val = 0;
     if (pitches === 0)
     {
@@ -159,14 +273,44 @@ pitchfx.Zone.prototype.getWhiffRate = function()
 
     angular.forEach(this.pitches, function(pitch)
     {
-        if (pitch.isWhiff())
+        if (pitch.isBallInPlay() || pitch.isFoul())
         {
-            whiffs++;
+            contact++;
         }
     });
 
-    val = whiffs / pitches;
-    return new pitchfx.ZoneStat(val, (val * 100).toFixed(0) + '% (' + whiffs + '/' + pitches + ')');
+    val = contact / pitches;
+    return new pitchfx.ZoneStat(val, (val * 100).toFixed(0) + '% (' + contact + '/' + pitches + ')');
+};
+
+/**
+ * Get the contact rate across all swings in this zone
+ *
+ * @returns {Number}
+ */
+pitchfx.Zone.prototype.getContactPerSwingRate = function()
+{
+    var contact = 0,
+        swings = 0,
+        val = 0;
+
+    angular.forEach(this.pitches, function(pitch)
+    {
+        if (pitch.isSwing())
+        {
+            swings++;
+        }
+        if (pitch.isBallInPlay() || pitch.isFoul())
+        {
+            contact++;
+        }
+    });
+    if (swings === 0)
+    {
+        return new pitchfx.ZoneStat(0, '0% (0/0)');
+    }
+    val = contact / swings;
+    return new pitchfx.ZoneStat(val, (val * 100).toFixed(0) + '% (' + contact + '/' + swings + ')');
 };
 
 /**

--- a/app/app/scripts/pojos/Zones.js
+++ b/app/app/scripts/pojos/Zones.js
@@ -142,6 +142,45 @@ pitchfx.Zones.prototype.getBIPRates = function()
 };
 
 /**
+ * Get a grid of balls in play per swing rates
+ *
+ * @returns {Array} a grid of rates
+ */
+pitchfx.Zones.prototype.getBIPPerSwingRates = function()
+{
+    return this.buildZoneStats(function(pitchZone)
+    {
+        return pitchZone.getBIPPerSwingRate();
+    });
+};
+
+/**
+ * Get the foul rates for each zone
+ *
+ * @returns {Array} a grid of rates
+ */
+pitchfx.Zones.prototype.getFoulRates = function()
+{
+    return this.buildZoneStats(function(pitchZone)
+    {
+        return pitchZone.getFoulRate();
+    });
+};
+
+/**
+ * Get a grid of fouls per swing rates
+ *
+ * @returns {Array} a grid of rates
+ */
+pitchfx.Zones.prototype.getFoulsPerSwingRates = function()
+{
+    return this.buildZoneStats(function(pitchZone)
+    {
+        return pitchZone.getFoulsPerSwingRate();
+    });
+};
+
+/**
  * Get the swing rates for each zone
  *
  * @returns {Array} a grid of rates
@@ -177,6 +216,32 @@ pitchfx.Zones.prototype.getWhiffsPerSwingRates = function()
     return this.buildZoneStats(function(pitchZone)
     {
         return pitchZone.getWhiffsPerSwingRate();
+    });
+};
+
+/**
+ * Get the contact rates for each zone
+ *
+ * @returns {Array} a grid of rates
+ */
+pitchfx.Zones.prototype.getContactRates = function()
+{
+    return this.buildZoneStats(function(pitchZone)
+    {
+        return pitchZone.getContactRate();
+    });
+};
+
+/**
+ * Get a grid of contact per swing rates
+ *
+ * @returns {Array} a grid of rates
+ */
+pitchfx.Zones.prototype.getContactPerSwingRates = function()
+{
+    return this.buildZoneStats(function(pitchZone)
+    {
+        return pitchZone.getContactPerSwingRate();
     });
 };
 

--- a/app/test/spec/pojos/Zones.js
+++ b/app/test/spec/pojos/Zones.js
@@ -1051,4 +1051,574 @@ describe('POJO: Zones', function()
         expect(calledStrikeRates[5][5].stat).toBe(0.4);
     });
 
+    it('Test contact/swing rate functions', function()
+    {
+        var zones = new pitchfx.Zones(),
+            pitches = [
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto grounds out, shortstop Jurickson Profar to first baseman Mitch Moreland.  "
+                },
+                "des": "In play, out(s)",
+                "hip":
+                {
+                    "des": "Groundout"
+                },
+                "pitch_type": "CH",
+                "px": 0,
+                "pz": 2.5,
+                "start_speed": 80.1,
+                "type": "X"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "B",
+                "des": "Ball",
+                "pz": 2.5,
+                "start_speed": 78.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "B",
+                "des": "Ball",
+                "pz": 2.5,
+                "start_speed": 80,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "B",
+                "des": "Ball",
+                "pz": 2.5,
+                "start_speed": 89.4,
+                "pitch_type": "FC"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Called Strike",
+                "pz": 2.5,
+                "start_speed": 72.5,
+                "pitch_type": "CU"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Foul",
+                "pz": 2.5,
+                "start_speed": 81.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "des": "In play, run(s)",
+                "hip":
+                {
+                    "des": "Double"
+                },
+                "pitch_type": "CU",
+                "px": 0,
+                "pz": 2.5,
+                "start_speed": 70,
+                "type": "X"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Called Strike",
+                "pz": 2.5,
+                "start_speed": 91.2,
+                "pitch_type": "SI"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Swinging Strike",
+                "pz": 2.5,
+                "start_speed": 83.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Foul",
+                "pz": 2.5,
+                "start_speed": 84.1,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Swinging Strike (Blocked)",
+                "pz": 2.5,
+                "start_speed": 84.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto singles on a line drive to right fielder Alex Rios.   Clete Thomas to 2nd.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Called Strike",
+                "pz": 2.5,
+                "start_speed": 93.8,
+                "pitch_type": "FF"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto singles on a line drive to right fielder Alex Rios.   Clete Thomas to 2nd.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Foul",
+                "pz": 2.5,
+                "start_speed": 92.9,
+                "pitch_type": "FF"
+            }],
+            contactRates, csv;
+
+        angular.forEach(pitches, function(pitch)
+        {
+            zones.addPitch(new pitchfx.Pitch(pitch));
+        });
+        contactRates = zones.getContactPerSwingRates();
+        csv = pitchfx.Zones.gridToCsv(contactRates, 'Contact Rates');
+
+        expect(/Contact Rates$/m.test(csv)).toBe(true);
+
+        expect(contactRates[0][0].stat).toBe(0);
+        expect(/^0,0,0$/m.test(csv)).toBe(true);
+
+        expect(contactRates[9][9].stat).toBe(0);
+        expect(/^9,9,0$/m.test(csv)).toBe(true);
+
+        expect(contactRates[5][5].stat.toFixed(2)).toBe('0.71'); // 5/7
+        expect(/^5,5,0.71\d+$/m.test(csv)).toBe(true);
+
+    });
+
+    it('Test foul/swing rate functions', function()
+    {
+        var zones = new pitchfx.Zones(),
+            pitches = [
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto grounds out, shortstop Jurickson Profar to first baseman Mitch Moreland.  "
+                },
+                "des": "In play, out(s)",
+                "hip":
+                {
+                    "des": "Groundout"
+                },
+                "pitch_type": "CH",
+                "px": 0,
+                "pz": 2.5,
+                "start_speed": 80.1,
+                "type": "X"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "B",
+                "des": "Ball",
+                "pz": 2.5,
+                "start_speed": 78.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "B",
+                "des": "Ball",
+                "pz": 2.5,
+                "start_speed": 80,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "B",
+                "des": "Ball",
+                "pz": 2.5,
+                "start_speed": 89.4,
+                "pitch_type": "FC"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Called Strike",
+                "pz": 2.5,
+                "start_speed": 72.5,
+                "pitch_type": "CU"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Foul",
+                "pz": 2.5,
+                "start_speed": 81.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "des": "In play, run(s)",
+                "hip":
+                {
+                    "des": "Double"
+                },
+                "pitch_type": "CU",
+                "px": 0,
+                "pz": 2.5,
+                "start_speed": 70,
+                "type": "X"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Called Strike",
+                "pz": 2.5,
+                "start_speed": 91.2,
+                "pitch_type": "SI"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Swinging Strike",
+                "pz": 2.5,
+                "start_speed": 83.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Foul",
+                "pz": 2.5,
+                "start_speed": 84.1,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Swinging Strike (Blocked)",
+                "pz": 2.5,
+                "start_speed": 84.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto singles on a line drive to right fielder Alex Rios.   Clete Thomas to 2nd.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Called Strike",
+                "pz": 2.5,
+                "start_speed": 93.8,
+                "pitch_type": "FF"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto singles on a line drive to right fielder Alex Rios.   Clete Thomas to 2nd.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Foul",
+                "pz": 2.5,
+                "start_speed": 92.9,
+                "pitch_type": "FF"
+            }],
+            foulRates, csv;
+
+        angular.forEach(pitches, function(pitch)
+        {
+            zones.addPitch(new pitchfx.Pitch(pitch));
+        });
+        foulRates = zones.getFoulsPerSwingRates();
+        csv = pitchfx.Zones.gridToCsv(foulRates, 'Foul Rates');
+
+        expect(/Foul Rates$/m.test(csv)).toBe(true);
+
+        expect(foulRates[0][0].stat).toBe(0);
+        expect(/^0,0,0$/m.test(csv)).toBe(true);
+
+        expect(foulRates[9][9].stat).toBe(0);
+        expect(/^9,9,0$/m.test(csv)).toBe(true);
+
+        expect(foulRates[5][5].stat.toFixed(2)).toBe('0.43'); // 3/7
+        expect(/^5,5,0.42\d+$/m.test(csv)).toBe(true);
+
+    });
+
+    it('Test bip/swing rate functions', function()
+    {
+        var zones = new pitchfx.Zones(),
+            pitches = [
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto grounds out, shortstop Jurickson Profar to first baseman Mitch Moreland.  "
+                },
+                "des": "In play, out(s)",
+                "hip":
+                {
+                    "des": "Groundout"
+                },
+                "pitch_type": "CH",
+                "px": 0,
+                "pz": 2.5,
+                "start_speed": 80.1,
+                "type": "X"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "B",
+                "des": "Ball",
+                "pz": 2.5,
+                "start_speed": 78.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "B",
+                "des": "Ball",
+                "pz": 2.5,
+                "start_speed": 80,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "B",
+                "des": "Ball",
+                "pz": 2.5,
+                "start_speed": 89.4,
+                "pitch_type": "FC"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Called Strike",
+                "pz": 2.5,
+                "start_speed": 72.5,
+                "pitch_type": "CU"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Foul",
+                "pz": 2.5,
+                "start_speed": 81.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto doubles (1) on a line drive to left fielder Jim Adduci.   Clete Thomas scores.  "
+                },
+                "des": "In play, run(s)",
+                "hip":
+                {
+                    "des": "Double"
+                },
+                "pitch_type": "CU",
+                "px": 0,
+                "pz": 2.5,
+                "start_speed": 70,
+                "type": "X"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Called Strike",
+                "pz": 2.5,
+                "start_speed": 91.2,
+                "pitch_type": "SI"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Swinging Strike",
+                "pz": 2.5,
+                "start_speed": 83.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Foul",
+                "pz": 2.5,
+                "start_speed": 84.1,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto strikes out swinging.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Swinging Strike (Blocked)",
+                "pz": 2.5,
+                "start_speed": 84.2,
+                "pitch_type": "CH"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto singles on a line drive to right fielder Alex Rios.   Clete Thomas to 2nd.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Called Strike",
+                "pz": 2.5,
+                "start_speed": 93.8,
+                "pitch_type": "FF"
+            },
+            {
+                "atbat":
+                {
+                    "des": "Josmil Pinto singles on a line drive to right fielder Alex Rios.   Clete Thomas to 2nd.  "
+                },
+                "px": 0,
+                "type": "S",
+                "des": "Foul",
+                "pz": 2.5,
+                "start_speed": 92.9,
+                "pitch_type": "FF"
+            }],
+            BIPPerSwingRates, csv;
+
+        angular.forEach(pitches, function(pitch)
+        {
+            zones.addPitch(new pitchfx.Pitch(pitch));
+        });
+        BIPPerSwingRates = zones.getBIPPerSwingRates();
+        csv = pitchfx.Zones.gridToCsv(BIPPerSwingRates, 'BIP Rates');
+
+        expect(/BIP Rates$/m.test(csv)).toBe(true);
+
+        expect(BIPPerSwingRates[0][0].stat).toBe(0);
+        expect(/^0,0,0$/m.test(csv)).toBe(true);
+
+        expect(BIPPerSwingRates[9][9].stat).toBe(0);
+        expect(/^9,9,0$/m.test(csv)).toBe(true);
+
+        expect(BIPPerSwingRates[5][5].stat.toFixed(2)).toBe('0.29'); // 2/7
+        expect(/^5,5,0.28\d+$/m.test(csv)).toBe(true);
+
+    });
+
 });


### PR DESCRIPTION
Karma tests include contact/swing, fouls/swing, and bip/swing functions. Also reorganizing accordion to the following order:

Pitch Results
- Swing Rate
- Contact Rate
- Whiff Rate
- Called Strike Rate
- ~~Foul Rate~~ (removing this to create space, but the getFoulRate functions still exist for now)
- Ball In Play Rate

Swing Results
- Contact/Swing
- Whiffs/Swing
- Fouls/Swing
- BIP/Swing

Batted Ball Results
- Grounders/BIP
- Linedrives/BIP
- Flyballs/BIP
- Popouts/BIP

Sabermetric Results
- wOBA/BIP
- BABIP

A great test case is comparing the charts of Brett Gardner and Mark Reynolds. Reynolds swings at a lot of pitches in and out of the zone compared to Gardner, and as a result, whiffs on a lot of them. Reynolds particularly like to swing at pitches up in (and out) of the zone, so his whiff rate chart shows some red in up in the zone. 

Looking at the swing results, even though Gardner is more selective in his swinging, he's a lot better at making contact than Reynolds is. Just as compelling is Gardner's whiff/swing chart vs. Reynolds' whiff/swing charts. So Gardner 1) doesn't like swinging at out of zone pitches, and 2) is better than average at making contact at all pitches when he does swing. Reynolds 1) likes to swing at all pitches, in the zone and out of zone, and 2) is not great at making contact when he does swing. Stark contrast.

An extension to these heatmaps would be incorporating more sabermetric results in addition to wOBA, but I can focus my efforts on #39 after this potential update. Let me know what you think of this @kruser, and if you like the addition or if it needs a little more work.
