### PR TITLE
Add contact rate to pitches table

### DIFF
--- a/app/app/scripts/controllers/pitchStats.js
+++ b/app/app/scripts/controllers/pitchStats.js
@@ -522,6 +522,7 @@ angular.module('pitchfxApp').controller('PitchstatsCtrl', ['$rootScope', '$scope
                             ball: 0,
                             strike: 0,
                             swing: 0,
+                            contact: 0,
                             whiff: 0,
                             foul: 0,
                             bip: 0,
@@ -548,6 +549,10 @@ angular.module('pitchfxApp').controller('PitchstatsCtrl', ['$rootScope', '$scope
                     if (pitch.isSwing())
                     {
                         aggregator.swing++;
+                    }
+                    if (pitch.isBallInPlay() || pitch.isFoul())
+                    {
+                        aggregator.contact++;
                     }
                     if (pitch.isBallInPlay())
                     {

--- a/app/app/views/partials/pitches.html
+++ b/app/app/views/partials/pitches.html
@@ -22,10 +22,10 @@
 							<th class="text-center" tooltip="Swing" tooltip-append-to-body="true">Swing</th>
 							<th class="text-center" tooltip="Contact" tooltip-append-to-body="true">Contact</th>
 							<th class="text-center" tooltip="Swing and a miss" tooltip-append-to-body="true">Whiff</th>
-							<th class="text-center" tooltip="Pitches hit in play, not necessarily a hit"
-								tooltip-append-to-body="true">BIP</th>
 							<th class="text-center" tooltip="Pitches resulting in a foul ball"
 								tooltip-append-to-body="true">Foul</th>
+							<th class="text-center" tooltip="Pitches hit in play, not necessarily a hit"
+								tooltip-append-to-body="true">BIP</th>
 							<th class="text-center" tooltip="Pitches resulting in a hit"
 								tooltip-append-to-body="true">Hit</th>
 							<th class="text-center" tooltip="Pitches hit in play, resulting in an out"
@@ -56,8 +56,8 @@
 						<td class="text-right" tooltip="{{row.swing}}" tooltip-append-to-body="true">{{row.swing/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.contact}}" tooltip-append-to-body="true">{{row.contact/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.whiff}}" tooltip-append-to-body="true">{{row.whiff/row.count*100|number:1}}%</td>
-						<td class="text-right" tooltip="{{row.bip}}" tooltip-append-to-body="true">{{row.bip/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.foul}}" tooltip-append-to-body="true">{{row.foul/row.count*100|number:1}}%</td>
+						<td class="text-right" tooltip="{{row.bip}}" tooltip-append-to-body="true">{{row.bip/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.hit}}" tooltip-append-to-body="true">{{row.hit/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.out}}" tooltip-append-to-body="true">{{row.out/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.grounder}}" tooltip-append-to-body="true">{{row.grounder/row.count*100|number:1}}%</td>

--- a/app/app/views/partials/pitches.html
+++ b/app/app/views/partials/pitches.html
@@ -20,11 +20,12 @@
 							<th class="text-center" tooltip="Called a ball" tooltip-append-to-body="true">B</th>
 							<th class="text-center" tooltip="A strike by any means" tooltip-append-to-body="true">K</th>
 							<th class="text-center" tooltip="Swing" tooltip-append-to-body="true">Swing</th>
+							<th class="text-center" tooltip="Contact" tooltip-append-to-body="true">Contact</th>
 							<th class="text-center" tooltip="Swing and a miss" tooltip-append-to-body="true">Whiff</th>
-							<th class="text-center" tooltip="Pitches resulting in a foul ball"
-								tooltip-append-to-body="true">Foul</th>
 							<th class="text-center" tooltip="Pitches hit in play, not necessarily a hit"
 								tooltip-append-to-body="true">BIP</th>
+							<th class="text-center" tooltip="Pitches resulting in a foul ball"
+								tooltip-append-to-body="true">Foul</th>
 							<th class="text-center" tooltip="Pitches resulting in a hit"
 								tooltip-append-to-body="true">Hit</th>
 							<th class="text-center" tooltip="Pitches hit in play, resulting in an out"
@@ -53,9 +54,10 @@
 						<td class="text-right" tooltip="{{row.ball}}" tooltip-append-to-body="true">{{row.ball/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.strike}}" tooltip-append-to-body="true">{{row.strike/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.swing}}" tooltip-append-to-body="true">{{row.swing/row.count*100|number:1}}%</td>
+						<td class="text-right" tooltip="{{row.contact}}" tooltip-append-to-body="true">{{row.contact/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.whiff}}" tooltip-append-to-body="true">{{row.whiff/row.count*100|number:1}}%</td>
-						<td class="text-right" tooltip="{{row.foul}}" tooltip-append-to-body="true">{{row.foul/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.bip}}" tooltip-append-to-body="true">{{row.bip/row.count*100|number:1}}%</td>
+						<td class="text-right" tooltip="{{row.foul}}" tooltip-append-to-body="true">{{row.foul/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.hit}}" tooltip-append-to-body="true">{{row.hit/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.out}}" tooltip-append-to-body="true">{{row.out/row.count*100|number:1}}%</td>
 						<td class="text-right" tooltip="{{row.grounder}}" tooltip-append-to-body="true">{{row.grounder/row.count*100|number:1}}%</td>


### PR DESCRIPTION
Small addition to #39, just adding contact rate to the pitches table. 'Called Strike' doesn't fit well in the header of the table, and I don't want to use the abbreviation 'CS' so that we avoid ambiguity. Will have to think about the rest of #39 some more in terms of adding more metrics to the pitches table and organization of the metrics.
