### PR TITLE
Fixed #73: Updated path to heatmap.js and data.js in scripts.html

### DIFF
--- a/app/app/views/templates/scripts.html
+++ b/app/app/views/templates/scripts.html
@@ -13,8 +13,8 @@
 <script src="//code.highcharts.com/highcharts.js"></script>
 <script src="//code.highcharts.com/highcharts-more.js"></script>
 <script src="//code.highcharts.com/modules/exporting.js"></script>
-<script src="//code.highcharts.com/maps/modules/data.js"></script>
-<script src="//code.highcharts.com/maps/modules/heatmap.js"></script>
+<script src="//code.highcharts.com/modules/data.js"></script>
+<script src="//code.highcharts.com/modules/heatmap.js"></script>
 
 
 <script type="text/javascript">


### PR DESCRIPTION
Highcharts changed the paths to heatmap.js and data.js with their v4.0.0 release, causing our heatmaps to show black backgrounds. I updated them here so that we're not sourcing the wrong paths. See https://github.com/highslide-software/highcharts.com/commit/9f57aa7026fc317a2a53e4eccae31aab076ae8c1 
